### PR TITLE
Document and test that …_RETURN and …_THROW macros evaluate their last argument only once or not at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ be constructable from the `message` type.
 
 `UNI_ENSURE_THROW` uses `UNI_ASSERT` but the expression is evaluated only once.
 
+`message` is evaluated only once if condition is false, and not at all if true.
+
 #### UNI_ENSURE_RETURN
 
 `UNI_ENSURE_RETURN(condition[, return_code])`
@@ -76,6 +78,8 @@ If `UNI_ENSURE_RETURN` is used in a function with `void` result type,
 `return_code` must be omitted.
 
 `UNI_ENSURE_RETURN` uses `UNI_ASSERT` but the expression is evaluated only once.
+
+`return_code` is evaluated only once if condition is false, and not at all if true.
 
 #### UNI_ENSURE_CONTINUE
 

--- a/test/uni_check_return.cpp
+++ b/test/uni_check_return.cpp
@@ -147,6 +147,21 @@ TEST_F(UniCheckReturnTest, ExtendedVersionShouldNotReturnIfConditionIsTrue)
 	EXPECT_FALSE(func());
 }
 
+TEST_F(UniCheckReturnTest, ExtendedVersionShouldNotEvaluateValueIfConditionIsTrue)
+{
+	int counter = 0;
+	const auto func =
+		[&counter]
+		{
+			UNI_CHECK_RETURN(true, ++counter);
+			return -1;
+		};
+
+	func();
+
+	EXPECT_EQ(counter, 0);
+}
+
 TEST_F(UniCheckReturnTest, ExtendedVersionShouldReturnIfConditionIsFalse)
 {
 	const auto func =
@@ -157,6 +172,21 @@ TEST_F(UniCheckReturnTest, ExtendedVersionShouldReturnIfConditionIsFalse)
 		};
 
 	EXPECT_TRUE(func());
+}
+
+TEST_F(UniCheckReturnTest, ExtendedVersionShouldEvaluateValueOnceIfConditionIsFalse)
+{
+	int counter = 0;
+	const auto func =
+		[&counter]
+		{
+			UNI_CHECK_RETURN(false, ++counter);
+			return -1;
+		};
+
+	func();
+
+	EXPECT_EQ(counter, 1);
 }
 
 } // namespace test

--- a/test/uni_check_throw.cpp
+++ b/test/uni_check_throw.cpp
@@ -100,6 +100,20 @@ TEST_F(UniCheckThrowTest, ShouldNotThrowIfConditionIsTrue)
 	EXPECT_NO_THROW(func());
 }
 
+TEST_F(UniCheckThrowTest, ShouldNotEvaluateMessageIfConditionIsTrue)
+{
+	auto message = "1error";
+	const auto func =
+		[&message]
+		{
+			UNI_CHECK_THROW(true, ++message);
+		};
+
+	func();
+
+	EXPECT_STREQ("1error", message);
+}
+
 TEST_F(UniCheckThrowTest, ShouldThrowIfConditionIsFalse)
 {
 	const auto func =
@@ -142,6 +156,20 @@ TEST_F(UniCheckThrowTest, ShouldThrowRuntimeErrorWithCorrectTextIfConditionIsFal
 	{
 		FAIL();
 	}
+}
+
+TEST_F(UniCheckThrowTest, ShouldEvaluateMessageOnceIfConditionIsFalse)
+{
+	auto message = "1error";
+	const auto func =
+		[&message]
+		{
+			UNI_CHECK_THROW(false, ++message);
+		};
+
+	EXPECT_ANY_THROW(func());
+
+	EXPECT_STREQ("error", message);
 }
 
 TEST_F(UniCheckThrowTest, ExtendedVersionShouldNotFailIfConditionIsTrue)
@@ -193,6 +221,20 @@ TEST_F(UniCheckThrowTest, ExtendedVersionShouldNotThrowIfConditionIsTrue)
 	EXPECT_NO_THROW(func());
 }
 
+TEST_F(UniCheckThrowTest, ExtendedVersionShouldNotEvaluateMessageIfConditionIsTrue)
+{
+	auto message = "1error";
+	const auto func =
+		[&message]
+		{
+			UNI_CHECK_THROW(true, test_exception, ++message);
+		};
+
+	func();
+
+	EXPECT_STREQ("1error", message);
+}
+
 TEST_F(UniCheckThrowTest, ExtendedVersionShouldThrowIfConditionIsFalse)
 {
 	const auto func =
@@ -202,6 +244,20 @@ TEST_F(UniCheckThrowTest, ExtendedVersionShouldThrowIfConditionIsFalse)
 		};
 
 	EXPECT_ANY_THROW(func());
+}
+
+TEST_F(UniCheckThrowTest, ExtendedVersionShouldEvaluateMessageOnceIfConditionIsFalse)
+{
+	auto message = "1error";
+	const auto func =
+		[&message]
+		{
+			UNI_CHECK_THROW(false, test_exception, ++message);
+		};
+
+	EXPECT_ANY_THROW(func());
+
+	EXPECT_STREQ("error", message);
 }
 
 TEST_F(UniCheckThrowTest, ExtendedVersionShouldThrowSelectedExceptionIfConditionIsFalse)

--- a/test/uni_ensure_return.cpp
+++ b/test/uni_ensure_return.cpp
@@ -147,6 +147,21 @@ TEST_F(UniEnsureReturnTest, ExtendedVersionShouldNotReturnIfConditionIsTrue)
 	EXPECT_FALSE(func());
 }
 
+TEST_F(UniEnsureReturnTest, ExtendedVersionShouldNotEvaluateResultIfConditionIsTrue)
+{
+	int counter = 0;
+	const auto func =
+		[&counter]
+		{
+			UNI_ENSURE_RETURN(true, ++counter);
+			return -1;
+		};
+
+	func();
+
+	EXPECT_EQ(0, counter);
+}
+
 TEST_F(UniEnsureReturnTest, ExtendedVersionShouldReturnIfConditionIsFalse)
 {
 	const auto func =
@@ -157,6 +172,21 @@ TEST_F(UniEnsureReturnTest, ExtendedVersionShouldReturnIfConditionIsFalse)
 		};
 
 	EXPECT_TRUE(func());
+}
+
+TEST_F(UniEnsureReturnTest, ExtendedVersionShouldEvauateResultOnceIfConditionIsFalse)
+{
+	int counter = 0;
+	const auto func =
+		[&counter]
+		{
+			UNI_ENSURE_RETURN(false, ++counter);
+			return -1;
+		};
+
+	func();
+
+	EXPECT_EQ(1, counter);
 }
 
 } // namespace test

--- a/test/uni_ensure_throw.cpp
+++ b/test/uni_ensure_throw.cpp
@@ -100,6 +100,20 @@ TEST_F(UniEnsureThrowTest, ShouldNotThrowIfConditionIsTrue)
 	EXPECT_NO_THROW(func());
 }
 
+TEST_F(UniEnsureThrowTest, ShouldNotEvaluateMessageIfConditionIsTrue)
+{
+	auto message = "1error";
+	const auto func =
+		[&message]
+		{
+			UNI_ENSURE_THROW(true, ++message);
+		};
+
+	func();
+
+	EXPECT_STREQ("1error", message);
+}
+
 TEST_F(UniEnsureThrowTest, ShouldThrowIfConditionIsFalse)
 {
 	const auto func =
@@ -142,6 +156,20 @@ TEST_F(UniEnsureThrowTest, ShouldThrowRuntimeErrorWithCorrectTextIfConditionIsFa
 	{
 		FAIL();
 	}
+}
+
+TEST_F(UniEnsureThrowTest, ShouldEvaluateMessageOnceIfConditionIsFalse)
+{
+	auto message = "1error";
+	const auto func =
+		[&message]
+		{
+			UNI_ENSURE_THROW(false, ++message);
+		};
+
+	EXPECT_ANY_THROW(func());
+
+	EXPECT_STREQ("error", message);
 }
 
 TEST_F(UniEnsureThrowTest, ExtendedVersionShouldNotFailIfConditionIsTrue)
@@ -193,6 +221,20 @@ TEST_F(UniEnsureThrowTest, ExtendedVersionShouldNotThrowIfConditionIsTrue)
 	EXPECT_NO_THROW(func());
 }
 
+TEST_F(UniEnsureThrowTest, ExtendedVersionShouldNotEvaluateMessageIfConditionIsTrue)
+{
+	auto message = "1error";
+	const auto func =
+		[&message]
+		{
+			UNI_ENSURE_THROW(true, test_exception, ++message);
+		};
+
+	func();
+
+	EXPECT_STREQ("1error", message);
+}
+
 TEST_F(UniEnsureThrowTest, ExtendedVersionShouldThrowIfConditionIsFalse)
 {
 	const auto func =
@@ -235,6 +277,20 @@ TEST_F(UniEnsureThrowTest, ExtendedVersionShouldThrowSelectedExceptionWithCorrec
 	{
 		FAIL();
 	}
+}
+
+TEST_F(UniEnsureThrowTest, ExtendedVersionShouldEvaluateMessageOnceIfConditionIsFalse)
+{
+	auto message = "1error";
+	const auto func =
+		[&message]
+		{
+			UNI_ENSURE_THROW(false, test_exception, ++message);
+		};
+
+	EXPECT_ANY_THROW(func());
+
+	EXPECT_STREQ("error", message);
 }
 
 } // namespace test


### PR DESCRIPTION
This allows writing checks with side effects.